### PR TITLE
Do not remove identity info from metadata

### DIFF
--- a/supportconfig/plugins/suse_public_cloud
+++ b/supportconfig/plugins/suse_public_cloud
@@ -158,8 +158,8 @@ function metadata() {
     if [ -e "/usr/bin/ec2metadata" ]; then
         echo "# /usr/bin/ec2metadata --api latest" >> $INFO_FILE
         /usr/bin/ec2metadata --api latest  >> $INFO_FILE
-	remove=("AccessKeyId" "SecretAccessKey"  "Token")
-	_sanitize_data "$INFO_FILE" "${remove[@]}"
+        remove=("AccessKeyId" "SecretAccessKey"  "Token")
+        _sanitize_data "$INFO_FILE" "${remove[@]}"
     fi
     if [ -e "/usr/sbin/azuremetadata" ]; then
         echo "# /usr/sbin/azuremetadata -e" >> $INFO_FILE
@@ -174,14 +174,12 @@ function metadata() {
     if [ -e "/usr/bin/azuremetadata" ]; then
         echo "# /usr/bin/azuremetadata --api latest" >> $INFO_FILE
         /usr/bin/azuremetadata --api latest >> $INFO_FILE
-	remove=("subscriptionId" "subscriptions")
-	_sanitize_data "$INFO_FILE" "${remove[@]}"
     fi
     if [ -e "/usr/bin/gcemetadata" ]; then
         echo "# /usr/bin/gcemetadata" >> $INFO_FILE
         /usr/bin/gcemetadata  >> $INFO_FILE
-	remove=("identity" "token")
-	_sanitize_data "$INFO_FILE" "${remove[@]}"
+        remove=("token")
+        _sanitize_data "$INFO_FILE" "${remove[@]}"
     fi
 }
 


### PR DESCRIPTION
Do not remove 'subscriptionId' from Azure metadata nor 'identity' from GCE metadata. This information is requested by SCC to link support requests for on-demand instances to customers.
Whitespace fixes.