### PR TITLE
Require dmidecode in spec file

### DIFF
--- a/supportutils-plugin-suse-public-cloud.spec
+++ b/supportutils-plugin-suse-public-cloud.spec
@@ -24,7 +24,9 @@ Group:          System/Monitoring
 Url:            https://github.com/SUSE/Enceladus
 Source0:        %{name}-%{version}.tar.bz2
 Requires:       supportutils
+%ifarch %ix86 ia64 x86_64 %arm aarch64
 Requires:       dmidecode
+%endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 

--- a/supportutils-plugin-suse-public-cloud.spec
+++ b/supportutils-plugin-suse-public-cloud.spec
@@ -24,6 +24,7 @@ Group:          System/Monitoring
 Url:            https://github.com/SUSE/Enceladus
 Source0:        %{name}-%{version}.tar.bz2
 Requires:       supportutils
+Requires:       dmidecode
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
Require dmidecode as it is used to determine the framework.