### PR TITLE
Accept upper case Amazon string in DMI table

### DIFF
--- a/supportconfig/plugins/suse_public_cloud
+++ b/supportconfig/plugins/suse_public_cloud
@@ -87,7 +87,7 @@ function framework() {
     echo "#==[ Determine Framework ]================================#" > $INFO_FILE
     echo "# dmidecode | grep -q amazon|Google|Microsoft" >> $INFO_FILE
 
-    if dmidecode | grep -q amazon; then
+    if dmidecode | grep -q -i amazon; then
         FRAMEWORK="EC2"
     fi
     if dmidecode | grep -q Google; then

--- a/supportutils-plugin-suse-public-cloud.spec
+++ b/supportutils-plugin-suse-public-cloud.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           supportutils-plugin-suse-public-cloud
-Version:        1.0.7
+Version:        1.0.8
 Release:        0
 Summary:        Public Cloud plugin for supportconfig
 License:        GPL-2.0+


### PR DESCRIPTION
When determining the CSP framework, ignore case when checking for Amazon.

Some instance types (at least `t3a.large`, possibly all instance types with AMD processors) have `Vendor: Amazon EC2` in their DMI table as opposed to `Version: 4.2.amazon` in Xen types. Framework detection currently fails on those. Ignoring case when grepping for `amazon` will fix the issue.