### PR TITLE
Remove duplicate RPM query

### DIFF
--- a/supportconfig/resources/rpmlist_Azure
+++ b/supportconfig/resources/rpmlist_Azure
@@ -11,5 +11,4 @@ python3-azurectl
 python3-azuremetadata
 regionServiceClientConfigAzure
 regionServiceClientConfigSAPAzure
-supportutils-plugin-suse-public-cloud
 WALinuxAgent

--- a/supportconfig/resources/rpmlist_EC2
+++ b/supportconfig/resources/rpmlist_EC2
@@ -13,4 +13,3 @@ python3-ec2publishimg
 python3-ec2uploadimg
 regionServiceClientConfigEC2
 regionServiceClientConfigSAPEC2
-supportutils-plugin-suse-public-cloud

--- a/supportconfig/resources/rpmlist_GCE
+++ b/supportconfig/resources/rpmlist_GCE
@@ -16,4 +16,3 @@ python-gcemetadata
 python3-gcemetadata
 regionServiceClientConfigGCE
 regionServiceClientConfigSAPGCE
-supportutils-plugin-suse-public-cloud


### PR DESCRIPTION
Do not query for the presence of supportutils-plugin-suse-public-cloud twice. The package is already listed in the common list of RPMs to check, no need to include the query in the CSP specific package lists.